### PR TITLE
MX-105 Change headline component to use 'title' property.

### DIFF
--- a/light-modules/spa-lm/dialogs/components/headline.yaml
+++ b/light-modules/spa-lm/dialogs/components/headline.yaml
@@ -1,7 +1,7 @@
 label: Headline
 form:
   properties:
-    text:
+    title:
       label: Headline
       $type: textField
       i18n: true

--- a/src/components/Headline.js
+++ b/src/components/Headline.js
@@ -1,5 +1,5 @@
 import React from "react";
 
-const Headline = (props) => <h2 className="Headline">{props.text}</h2>;
+const Headline = (props) => <h2 className="Headline">{props.title}</h2>;
 
 export default Headline;


### PR DESCRIPTION
# Jira

https://magnolia-cms.atlassian.net/browse/MX-105

# Description

Changed headline to have "title" property instead of "text" property - so that things are smoother when the developer changes the Headline component.

# Ping docs

No action needed from docs. This is adjusting the demo project so that the docs are smooth and correct.
